### PR TITLE
修复发送按钮需要点两次才能发送的问题

### DIFF
--- a/web_demo2.py
+++ b/web_demo2.py
@@ -45,19 +45,14 @@ for i, (query, response) in enumerate(st.session_state.history):
         st.markdown(query)
     with st.chat_message(name="assistant", avatar="assistant"):
         st.markdown(response)
-with st.chat_message(name="user", avatar="user"):
-    input_placeholder = st.empty()
-with st.chat_message(name="assistant", avatar="assistant"):
-    message_placeholder = st.empty()
 
-prompt_text = st.text_area(label="用户命令输入",
-                           height=100,
-                           placeholder="请在这儿输入您的命令")
+prompt_text = st.chat_input(placeholder="请在这儿输入您的命令")
+if prompt_text:
+    with st.chat_message(name="user", avatar="user"):
+        st.markdown(prompt_text)
+    with st.chat_message(name="assistant", avatar="assistant"):
+        message_placeholder = st.empty()
 
-button = st.button("发送", key="predict")
-
-if button:
-    input_placeholder.markdown(prompt_text)
     history, past_key_values = st.session_state.history, st.session_state.past_key_values
     for response, history, past_key_values in model.stream_chat(tokenizer, prompt_text, history,
                                                                 past_key_values=past_key_values,


### PR DESCRIPTION
直接换成效果更好的chat_input了，同时调整了下占位符（那两个空消息框）的输出时机（仅点发送后才显示）

新的效果图
![image](https://github.com/THUDM/ChatGLM2-6B/assets/1598262/3645702f-61ee-464c-86b1-700f2cb2d7cd)
